### PR TITLE
added support for programmable preamble and postamble time

### DIFF
--- a/src/RS485.cpp
+++ b/src/RS485.cpp
@@ -30,13 +30,25 @@ RS485Class::RS485Class(HardwareSerial& hwSerial, int txPin, int dePin, int rePin
 
 void RS485Class::begin(unsigned long baudrate)
 {
-  begin(baudrate, SERIAL_8N1);
+  begin(baudrate, SERIAL_8N1,RS485_DEFAULT_PRE_DELAY,RS485_DEFAULT_POST_DELAY);
+}
+
+void RS485Class::begin(unsigned long baudrate, int predelay, int postdelay)
+{
+  begin(baudrate, SERIAL_8N1,predelay,postdelay);
 }
 
 void RS485Class::begin(unsigned long baudrate, uint16_t config)
 {
+  begin(baudrate,config,RS485_DEFAULT_PRE_DELAY,RS485_DEFAULT_POST_DELAY);
+}
+
+void RS485Class::begin(unsigned long baudrate, uint16_t config, int predelay, int postdelay)
+{
   _baudrate = baudrate;
   _config = config;
+  _predelay = predelay;
+  _postdelay = postdelay;
 
   if (_dePin > -1) {
     pinMode(_dePin, OUTPUT);
@@ -107,7 +119,7 @@ void RS485Class::beginTransmission()
 {
   if (_dePin > -1) {
     digitalWrite(_dePin, HIGH);
-    delayMicroseconds(50);
+    if (_predelay) delayMicroseconds(_predelay);
   }
 
   _transmisionBegun = true;
@@ -118,7 +130,7 @@ void RS485Class::endTransmission()
   _serial->flush();
 
   if (_dePin > -1) {
-    delayMicroseconds(50);
+    if (_postdelay) delayMicroseconds(_postdelay);
     digitalWrite(_dePin, LOW);
   }
 
@@ -166,4 +178,4 @@ void RS485Class::setPins(int txPin, int dePin, int rePin)
   _rePin = rePin;
 }
 
-RS485Class RS485(SERIAL_PORT_HARDWARE, RS485_DEFAULT_TX_PIN, RS485_DEFAULT_DE_PIN, RS485_DEFAULT_RE_PIN);
+RS485Class RS485(SERIAL_PORT_HARDWARE, RS485_DEFAULT_TX_PIN, RS845_DEFAULT_DE_PIN, RS845_DEFAULT_RE_PIN);

--- a/src/RS485.h
+++ b/src/RS485.h
@@ -29,12 +29,16 @@
 #endif
 
 #ifdef __AVR__
-#define RS485_DEFAULT_DE_PIN 2
-#define RS485_DEFAULT_RE_PIN -1
+#define RS845_DEFAULT_DE_PIN 2
+#define RS845_DEFAULT_RE_PIN -1
 #else
-#define RS485_DEFAULT_DE_PIN A6
-#define RS485_DEFAULT_RE_PIN A5
+#define RS845_DEFAULT_DE_PIN A6
+#define RS845_DEFAULT_RE_PIN A5
 #endif
+
+
+#define RS485_DEFAULT_PRE_DELAY 50
+#define RS485_DEFAULT_POST_DELAY 50
 
 class RS485Class : public Stream {
   public:
@@ -42,6 +46,8 @@ class RS485Class : public Stream {
 
     virtual void begin(unsigned long baudrate);
     virtual void begin(unsigned long baudrate, uint16_t config);
+    virtual void begin(unsigned long baudrate, int predelay, int postdelay);
+    virtual void begin(unsigned long baudrate, uint16_t config, int predelay, int postdelay);
     virtual void end();
     virtual int available();
     virtual int peek();
@@ -66,6 +72,8 @@ class RS485Class : public Stream {
     int _txPin;
     int _dePin;
     int _rePin;
+    int _predelay;
+    int _postdelay;
 
     bool _transmisionBegun;
     unsigned long _baudrate;


### PR DESCRIPTION
this modification is necessary because the 50 usec delay is arbitrary and may depend on baud rate and other factors. also the 50 us delay at end of transmission may lead to contentions in case another device tries to transmit immediately.
the modification has been done so that library is totally backwards compatible.