### PR TITLE
Add ::setDelays method

### DIFF
--- a/src/RS485.cpp
+++ b/src/RS485.cpp
@@ -47,8 +47,10 @@ void RS485Class::begin(unsigned long baudrate, uint16_t config, int predelay, in
 {
   _baudrate = baudrate;
   _config = config;
-  _predelay = predelay;
-  _postdelay = postdelay;
+
+  // Set only if not already initialized with ::setDelays
+  _predelay = _predelay == 0 ? predelay : _predelay;
+  _postdelay = _postdelay == 0 ? postdelay : _postdelay;
 
   if (_dePin > -1) {
     pinMode(_dePin, OUTPUT);
@@ -176,6 +178,12 @@ void RS485Class::setPins(int txPin, int dePin, int rePin)
   _txPin = txPin;
   _dePin = dePin;
   _rePin = rePin;
+}
+
+void RS485Class::setDelays(int predelay, int postdelay)
+{
+  _predelay = predelay;
+  _postdelay = postdelay;
 }
 
 RS485Class RS485(SERIAL_PORT_HARDWARE, RS485_DEFAULT_TX_PIN, RS485_DEFAULT_DE_PIN, RS485_DEFAULT_RE_PIN);

--- a/src/RS485.h
+++ b/src/RS485.h
@@ -67,6 +67,8 @@ class RS485Class : public Stream {
 
     void setPins(int txPin, int dePin, int rePin);
 
+    void setDelays(int predelay, int postdelay);
+
   private:
     HardwareSerial* _serial;
     int _txPin;


### PR DESCRIPTION
Add `::setDelays` to set `_preDelay` an `_postDelay` not at `::begin`.

This helps to reuse the library in already dependent libraries (e.g. [ArduinoModbus](https://github.com/arduino-libraries/ArduinoModbus)) without changes downstream.

Tested successfully with ArduinoModbus on Arduino Portenta Machine Control.