### PR TITLE
Alternate serial port

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -581,3 +581,21 @@ None.
 * [noReceive()](#noreceive)
 * [sendBreak()](#sendbreak)
 * [sendBreakMicroseconds()](#sendbreakmicroseconds)
+
+### `setSerial()`
+
+Modify the hardware serial used to communicate with the MAX3157 chipset. Must use with RS485.setPins() to update new txPin.
+
+#### Syntax 
+
+```
+RS485.setSerial(HardwareSerial* serial)
+```
+
+#### Parameters
+
+* _serial: hardware serial port to use.
+
+#### Returns
+
+None.

--- a/src/RS485.cpp
+++ b/src/RS485.cpp
@@ -186,4 +186,9 @@ void RS485Class::setDelays(int predelay, int postdelay)
   _postdelay = postdelay;
 }
 
+void RS485Class::setSerial(HardwareSerial* serial)
+{
+  _serial = serial;
+}
+
 RS485Class RS485(SERIAL_PORT_HARDWARE, RS485_DEFAULT_TX_PIN, RS485_DEFAULT_DE_PIN, RS485_DEFAULT_RE_PIN);

--- a/src/RS485.h
+++ b/src/RS485.h
@@ -69,6 +69,8 @@ class RS485Class : public Stream {
 
     void setDelays(int predelay, int postdelay);
 
+    void setSerial(HardwareSerial* serial);
+
   private:
     HardwareSerial* _serial;
     int _txPin;


### PR DESCRIPTION
This modification will allow this library to be used with alternate serial ports on boards that have more than one hardware serial port. Changes originally found here: https://forum.arduino.cc/t/arduinomodbus-for-other-shields-and-with-different-serial-port/878764