### PR TITLE
Fix for inverted pin names in end function

### DIFF
--- a/src/RS485.cpp
+++ b/src/RS485.cpp
@@ -83,13 +83,13 @@ void RS485Class::end()
 {
   _serial->end();
 
-  if (_rePin > -1) {
-    digitalWrite(_rePin, LOW);
+  if (_dePin > -1) {
+    digitalWrite(_dePin, LOW);
     pinMode(_dePin, INPUT);
   }
   
-  if (_dePin > -1) {
-    digitalWrite(_dePin, LOW);
+  if (_rePin > -1) {
+    digitalWrite(_rePin, LOW);
     pinMode(_rePin, INPUT);
   }
 }


### PR DESCRIPTION
Related issue: https://github.com/arduino-libraries/ArduinoRS485/issues/29

I preferred to change the two lines (if and digitalwrite) instead of the pinmode one to keep consistency (in the remaining parts of the library DE is always before RE)