### PR TITLE
Update RS485.h

### DIFF
--- a/src/RS485.h
+++ b/src/RS485.h
@@ -30,6 +30,10 @@
 #endif
 #endif
 
+#ifndef RS485_SERIAL_PORT
+#define RS485_SERIAL_PORT Serial
+#endif
+
 #ifdef __AVR__
 #define RS485_DEFAULT_DE_PIN 2
 #define RS485_DEFAULT_RE_PIN -1


### PR DESCRIPTION
Enables users to override `RS485_SERIAL_PORT` settings, and use `Serial` by default