### PR TITLE
More general solution for external RS485_DEFAULT_DE_PIN and RS485_DEFAULT_RE_PIN definition

### DIFF
--- a/src/RS485.h
+++ b/src/RS485.h
@@ -30,6 +30,7 @@
 #endif
 #endif
 
+#ifndef RS485_DEFAULT_DE_PIN
 #ifdef __AVR__
 #define RS485_DEFAULT_DE_PIN 2
 #define RS485_DEFAULT_RE_PIN -1
@@ -40,7 +41,6 @@
 #define RS485_DEFAULT_DE_PIN A4
 #define RS485_DEFAULT_RE_PIN A5
 #else
-#ifndef RS485_DEFAULT_DE_PIN
 #define RS485_DEFAULT_DE_PIN A6
 #define RS485_DEFAULT_RE_PIN A5
 #endif


### PR DESCRIPTION
Hello,

We at [Controllino](https://www.controllino.com/) are now updating our AVR devices board support packages, in some of them we have RS485 ports and by defining RS485_SERIAL_PORT,  RS485_DEFAULT_TX_PIN,  RS485_DEFAULT_RE_PIN, RS485_DEFAULT_DE_PIN, we pretend to add support for ArduinoRS485 and ArduinoModbus libraries.

But without the change in this PR these AVR devices will be forced to:
```
#ifdef __AVR__
#define RS485_DEFAULT_DE_PIN 2
#define RS485_DEFAULT_RE_PIN -1
```

Best Regards.